### PR TITLE
Fix for privacy by not displaying received clipboard content on stdout for non-debug build

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ impl Server {
 // IMPORTANT: Clipboard operations can be blocking!
 // Using spawn_blocking ensures we don't block the async runtime thread.
 async fn write_to_clipboard(data: Bytes) -> Result<(), AppError> {
+    #[cfg(debug_assertions)]
     println!(
         "attempt to write string to clipboard: {}",
         String::from_utf8(data.to_vec())?


### PR DESCRIPTION
Hi,
My attempt to fix #2.
Regards,